### PR TITLE
Issue 9159

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1543,10 +1543,14 @@ def _create_sagemaker_endpoint(
         "InitialVariantWeight": 1,
     }
     config_name = _get_sagemaker_config_name(endpoint_name)
+    config_tags = [{"Key": "app_name", "Value": endpoint_name}]
+    if tags:
+        tags = [{"Key": key, "Value": str(value)} for key, value in tags.items()]
+        config_tags.extend(tags)
     endpoint_config_kwargs = {
         "EndpointConfigName": config_name,
         "ProductionVariants": [production_variant],
-        "Tags": [{"Key": "app_name", "Value": endpoint_name}],
+        "Tags": config_tags,
     }
     if async_inference_config:
         endpoint_config_kwargs["AsyncInferenceConfig"] = async_inference_config
@@ -1560,7 +1564,7 @@ def _create_sagemaker_endpoint(
     endpoint_response = sage_client.create_endpoint(
         EndpointName=endpoint_name,
         EndpointConfigName=config_name,
-        Tags=[],
+        Tags=tags or [],
     )
     _logger.info("Created endpoint with arn: %s", endpoint_response["EndpointArn"])
 
@@ -1639,7 +1643,7 @@ def _update_sagemaker_endpoint(
                                  For more information, see https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DataCaptureConfig.html.
                                  Defaults to ``None``.
     :param env: A dictionary of environment variables to set for the model.
-    :param tags: A dictionary of tags to apply to the endpoint.
+    :param tags: A dictionary of tags to apply to the endpoint configuration.
     """
     if mode not in [DEPLOYMENT_MODE_ADD, DEPLOYMENT_MODE_REPLACE]:
         msg = f"Invalid mode `{mode}` for deployment to a pre-existing application"
@@ -1692,11 +1696,14 @@ def _update_sagemaker_endpoint(
     # Create the new endpoint configuration and update the endpoint
     # to adopt the new configuration
     new_config_name = _get_sagemaker_config_name(endpoint_name)
-    # This is the hardcoded config for endpoint
+    config_tags = [{"Key": "app_name", "Value": endpoint_name}]
+    if tags:
+        tags = [{"Key": key, "Value": str(value)} for key, value in tags.items()]
+        config_tags.extend(tags)
     endpoint_config_kwargs = {
         "EndpointConfigName": new_config_name,
         "ProductionVariants": production_variants,
-        "Tags": [{"Key": "app_name", "Value": endpoint_name}],
+        "Tags": config_tags,
     }
     if async_inference_config:
         endpoint_config_kwargs["AsyncInferenceConfig"] = async_inference_config

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1336,6 +1336,19 @@ def _get_sagemaker_config_name(endpoint_name):
     return f"{endpoint_name}-config-{get_unique_resource_id()}"
 
 
+def _get_sagemaker_config_tags(endpoint_name):
+    return [{"Key": "app_name", "Value": endpoint_name}]
+
+def _add_sagemaker_tags(tags, config_tags):
+    """
+    Convert dict of tags to list for SageMaker and adds to config tags list
+    """
+    if tags:
+        tags = [{"Key": key, "Value": str(value)} for key, value in tags.items()]
+        config_tags.extend(tags)
+
+    return tags
+
 def _create_sagemaker_transform_job(
     job_name,
     model_name,
@@ -1543,10 +1556,8 @@ def _create_sagemaker_endpoint(
         "InitialVariantWeight": 1,
     }
     config_name = _get_sagemaker_config_name(endpoint_name)
-    config_tags = [{"Key": "app_name", "Value": endpoint_name}]
-    if tags:
-        tags = [{"Key": key, "Value": str(value)} for key, value in tags.items()]
-        config_tags.extend(tags)
+    config_tags = _get_sagemaker_config_tags(endpoint_name)
+    tags_list = _add_sagemaker_tags(tags, config_tags)
     endpoint_config_kwargs = {
         "EndpointConfigName": config_name,
         "ProductionVariants": [production_variant],
@@ -1564,7 +1575,7 @@ def _create_sagemaker_endpoint(
     endpoint_response = sage_client.create_endpoint(
         EndpointName=endpoint_name,
         EndpointConfigName=config_name,
-        Tags=tags or [],
+        Tags=tags_list or [],
     )
     _logger.info("Created endpoint with arn: %s", endpoint_response["EndpointArn"])
 
@@ -1696,10 +1707,8 @@ def _update_sagemaker_endpoint(
     # Create the new endpoint configuration and update the endpoint
     # to adopt the new configuration
     new_config_name = _get_sagemaker_config_name(endpoint_name)
-    config_tags = [{"Key": "app_name", "Value": endpoint_name}]
-    if tags:
-        tags = [{"Key": key, "Value": str(value)} for key, value in tags.items()]
-        config_tags.extend(tags)
+    config_tags = _get_sagemaker_config_tags(endpoint_name)
+    tags_list = _add_sagemaker_tags(tags, config_tags)
     endpoint_config_kwargs = {
         "EndpointConfigName": new_config_name,
         "ProductionVariants": production_variants,

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -190,14 +190,12 @@ class SageMakerResponse(BaseResponse):
         https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
         """
         arn = self.request_params["ResourceArn"]
-        if 'model' in arn:
-            sagemaker_resource = 'models'
-        elif 'endpoint' in arn:
-            sagemaker_resource = 'endpoints'
+        if "model" in arn:
+            sagemaker_resource = "models"
+        elif "endpoint" in arn:
+            sagemaker_resource = "endpoints"
         results = self.sagemaker_backend.list_tags(
-            resource_arn=arn,
-            region_name=self.region,
-            resource_type=sagemaker_resource
+            resource_arn=arn, region_name=self.region, resource_type=sagemaker_resource
         )
 
         return json.dumps({"Tags": results, "NextToken": None})
@@ -518,13 +516,19 @@ class SageMakerBackend(BaseBackend):
             summaries.append(summary)
         return summaries
 
-    def list_tags(self, resource_arn, region_name, resource_type):  # pylint: disable=unused-argument
+    def list_tags(
+        self, resource_arn, region_name, resource_type
+    ):  # pylint: disable=unused-argument
         """
         Modifies backend state during calls to the SageMaker "ListTags" API
         https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
         """
         resource_values = getattr(self, resource_type).values()
-        sagemaker_resource = next(sagemaker_resource for sagemaker_resource in resource_values if sagemaker_resource.arn == resource_arn)
+        sagemaker_resource = next(
+            sagemaker_resource
+            for sagemaker_resource in resource_values
+            if sagemaker_resource.arn == resource_arn
+        )
         return sagemaker_resource.resource.tags
 
     def create_model(

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -189,11 +189,15 @@ class SageMakerResponse(BaseResponse):
         Handler for the SageMaker "ListTags" API call documented here:
         https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
         """
-        model_arn = self.request_params["ResourceArn"]
-
+        arn = self.request_params["ResourceArn"]
+        if 'model' in arn:
+            sagemaker_resource = 'models'
+        elif 'endpoint' in arn:
+            sagemaker_resource = 'endpoints'
         results = self.sagemaker_backend.list_tags(
-            resource_arn=model_arn,
+            resource_arn=arn,
             region_name=self.region,
+            resource_type=sagemaker_resource
         )
 
         return json.dumps({"Tags": results, "NextToken": None})
@@ -514,13 +518,14 @@ class SageMakerBackend(BaseBackend):
             summaries.append(summary)
         return summaries
 
-    def list_tags(self, resource_arn, region_name):  # pylint: disable=unused-argument
+    def list_tags(self, resource_arn, region_name, resource_type):  # pylint: disable=unused-argument
         """
         Modifies backend state during calls to the SageMaker "ListTags" API
         https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
         """
-        model = next(model for model in self.models.values() if model.arn == resource_arn)
-        return model.resource.tags
+        resource_values = getattr(self, resource_type).values()
+        sagemaker_resource = next(sagemaker_resource for sagemaker_resource in resource_values if sagemaker_resource.arn == resource_arn)
+        return sagemaker_resource.resource.tags
 
     def create_model(
         self, model_name, primary_container, execution_role_arn, tags, region_name, vpc_config=None

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -423,7 +423,7 @@ def test_attempting_to_deploy_in_asynchronous_mode_without_archiving_throws_exce
 
 
 @mock_sagemaker_aws_services
-def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_tags_from_local(  # update this test
+def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_tags_from_local(
     pretrained_model, sagemaker_client, sagemaker_deployment_client, monkeypatch
 ):
     expected_tags = [{"Key": "key1", "Value": "value1"}, {"Key": "key2", "Value": "value2"}]

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -423,7 +423,7 @@ def test_attempting_to_deploy_in_asynchronous_mode_without_archiving_throws_exce
 
 
 @mock_sagemaker_aws_services
-def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_tags_from_local(
+def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_tags_from_local(  # update this test
     pretrained_model, sagemaker_client, sagemaker_deployment_client, monkeypatch
 ):
     expected_tags = [{"Key": "key1", "Value": "value1"}, {"Key": "key2", "Value": "value2"}]
@@ -447,10 +447,12 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_tags_
     model_name = endpoint_production_variants[0]["VariantName"]
     description = sagemaker_client.describe_model(ModelName=model_name)
 
-    tags = sagemaker_client.list_tags(ResourceArn=description["ModelArn"])
+    model_tags = sagemaker_client.list_tags(ResourceArn=description["ModelArn"])
+    endpoint_tags = sagemaker_client.list_tags(ResourceArn=endpoint_description["EndpointArn"])
 
     # Extra tags exist besides the ones we set, so avoid strict equality
-    assert all(tag in tags["Tags"] for tag in expected_tags)
+    assert all(tag in model_tags["Tags"] for tag in expected_tags)
+    assert all(tag in endpoint_tags["Tags"] for tag in expected_tags)
 
 
 @pytest.mark.parametrize("proxies_enabled", [True, False])
@@ -612,10 +614,12 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_tags_from_l
     model_name = endpoint_production_variants[0]["VariantName"]
     description = sagemaker_client.describe_model(ModelName=model_name)
 
-    tags = sagemaker_client.list_tags(ResourceArn=description["ModelArn"])
+    model_tags = sagemaker_client.list_tags(ResourceArn=description["ModelArn"])
+    endpoint_tags = sagemaker_client.list_tags(ResourceArn=endpoint_description["EndpointArn"])
 
     # Extra tags exist besides the ones we set, so avoid strict equality
-    assert all(tag in tags["Tags"] for tag in expected_tags)
+    assert all(tag in model_tags["Tags"] for tag in expected_tags)
+    assert all(tag in endpoint_tags["Tags"] for tag in expected_tags)
 
 
 @pytest.mark.parametrize("proxies_enabled", [True, False])


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #[9159] (https://github.com/mlflow/mlflow/issues/9159)

## What changes are proposed in this pull request?
Fixing a bug where tags were not being added to sagemaker endpoints during deployment. Also added logic to add custom tags to sagemaker config resources as well.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Users of the SageMaker deployment functionality can now configure custom tags for both endpoints and endpoint configuration resources from both the CLI and Python SDK.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
